### PR TITLE
allow @responseType tags to override return type

### DIFF
--- a/swagger-doclet/src/main/java/com/tenxerconsulting/swagger/doclet/parser/ApiMethodParser.java
+++ b/swagger-doclet/src/main/java/com/tenxerconsulting/swagger/doclet/parser/ApiMethodParser.java
@@ -188,7 +188,7 @@ public class ApiMethodParser {
 
 		// look for a custom return type, this is useful where we return a jaxrs Response in the method signature
 		// but typically return a different object in its entity (such as for a 201 created response)
-		String customReturnTypeName = ParserHelper.getInheritableTagValue(this.methodDoc, this.options.getResponseTypeTags(), this.options);
+		String customReturnTypeName = ParserHelper.responseTypeTagOf(this.methodDoc, this.options);
 		NameToType nameToType = readCustomReturnType(customReturnTypeName, viewClasses);
 		if (nameToType != null) {
 			returnTypeName = nameToType.returnTypeName;

--- a/swagger-doclet/src/main/java/com/tenxerconsulting/swagger/doclet/parser/ClassDocCache.java
+++ b/swagger-doclet/src/main/java/com/tenxerconsulting/swagger/doclet/parser/ClassDocCache.java
@@ -59,4 +59,13 @@ public class ClassDocCache {
 		return null;
 	}
 
+	/**
+	 * This finds a class doc matching the given type name
+	 * @param type The type to find a matching class doc for
+	 * @return The class doc or null if none matched
+	 */
+	public ClassDoc findByName(String typeName) {
+		return this.typeNameToClass.get(typeName);
+	}
+
 }

--- a/swagger-doclet/src/main/java/com/tenxerconsulting/swagger/doclet/parser/JaxRsAnnotationParser.java
+++ b/swagger-doclet/src/main/java/com/tenxerconsulting/swagger/doclet/parser/JaxRsAnnotationParser.java
@@ -158,7 +158,8 @@ public class JaxRsAnnotationParser {
                     for (MethodDoc method : currentClassDoc.methods()) {
                         // if the method has @Path but no Http method then its an entry point to a sub resource
                         if (!ParserHelper.resolveMethodPath(method, this.options).isEmpty() && HttpMethod.fromMethod(method, options) == null) {
-                            ClassDoc subResourceClassDoc = classCache.findByType(method.returnType());
+                            String responseTypeTag = ParserHelper.responseTypeTagOf(method, this.options);
+                            ClassDoc subResourceClassDoc = responseTypeTag == null ? classCache.findByType(method.returnType()) : classCache.findByName(responseTypeTag);
                             // look for a custom return type, this is useful where we return a jaxrs Resource in the method signature
                             // which typically returns a different subResource object
                             if (subResourceClassDoc == null) {

--- a/swagger-doclet/src/main/java/com/tenxerconsulting/swagger/doclet/parser/ParserHelper.java
+++ b/swagger-doclet/src/main/java/com/tenxerconsulting/swagger/doclet/parser/ParserHelper.java
@@ -619,6 +619,19 @@ public class ParserHelper {
     }
 
     /**
+	 * This gets the FQN of a method response type from tags.
+	 * @param methodDoc The method
+	 * @param options The doclet options
+	 * @return The FQN of the response type tag or null if none found
+	 * @see com.tenxerconsulting.swagger.doclet.parser.ApiMethodParser.readCustomReturnType(String, ClassDoc[])
+	 */
+	public static String responseTypeTagOf(MethodDoc methodDoc, DocletOptions options) {
+		// looking for a custom return type, this is useful where we return a jaxrs Response in the method signature
+		// but typically return a different object in its entity (such as for a 201 created response)
+		return getInheritableTagValue(methodDoc, options.getResponseTypeTags(), options);
+	}
+
+	/**
      * This gets parameterized types of the given type substituting variable types if necessary
      *
      * @param type        The raw type such as Batch&lt;Item&gt; or Batch&lt;T, Y&gt;


### PR DESCRIPTION
`JaxRsParser` ignored `@returnType` method annotations (unlike `ApiMethodParser`, which handled them as expected), which may lead to incorrect behavior like sub-resources not being recognized as such